### PR TITLE
fix(ci): フォーク PR の pull_request_target ビルド検証失敗を修正

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,8 +11,6 @@ on:
     types:
       - opened
       - synchronize
-    paths:
-      - .github/workflows/docker.yml
   pull_request_target:
     branches:
       - main
@@ -77,7 +75,36 @@ jobs:
   docker-ci:
     name: Docker CI
     needs: approval-gate
-    if: always() && needs.approval-gate.result == 'success' && (github.event.action != 'closed' || github.event.pull_request.merged == true)
+    # pull_request_target はフォーク PR の head SHA をチェックアウトできない
+    # （GitHub のセキュリティ制約により actions/checkout が拒否するため）。
+    # フォーク PR かつ未マージの場合は、下の docker-ci-fork-preview（権限が
+    # 絞られた安全な pull_request トリガー側）にビルド検証を委ね、
+    # このジョブはスキップする。
+    if: >-
+      always() &&
+      needs.approval-gate.result == 'success' &&
+      github.event_name == 'pull_request_target' &&
+      (github.event.action != 'closed' || github.event.pull_request.merged == true) &&
+      !(github.event.pull_request.head.repo.full_name != github.repository && github.event.pull_request.merged != true)
+    uses: book000/templates/.github/workflows/reusable-docker.yml@249109e57d1bc836c5a4e1bbf4e446ad2c286deb # master
+    with:
+      targets: >-
+        [
+          { imageName: "book000/mitm-packet-sniffer", context: "mitmproxy-addon", file: "mitmproxy-addon/Dockerfile", packageName: "mitm-packet-sniffer" }
+        ]
+      platforms: linux/amd64,linux/arm64
+    secrets:
+      DOCKER_USERNAME: ${{ github.actor }}
+      DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
+  docker-ci-fork-preview:
+    name: Docker CI
+    # フォーク PR は pull_request_target 側でビルド検証できないため、
+    # 権限が絞られた安全な pull_request トリガーでビルド検証のみ行う
+    # （is-merged は常に false になるため、レジストリへの push は発生しない）
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name != github.repository
     uses: book000/templates/.github/workflows/reusable-docker.yml@249109e57d1bc836c5a4e1bbf4e446ad2c286deb # master
     with:
       targets: >-

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -78,9 +78,7 @@ jobs:
     name: Docker CI
     needs: approval-gate
     if: always() && needs.approval-gate.result == 'success' && (github.event.action != 'closed' || github.event.pull_request.merged == true)
-    # book000/templates#430（fix/allow-unsafe-pr-checkout-input, 未マージ）を暫定的に参照している。
-    # マージ後は master の SHA に更新すること。
-    uses: book000/templates/.github/workflows/reusable-docker.yml@0ae8b523900db5d32e3c2c2c2f1d286901c8e54a # fix/allow-unsafe-pr-checkout-input
+    uses: book000/templates/.github/workflows/reusable-docker.yml@1d3c112ba6b8e5ac13c24a8e3892f92b98ea35ac # master
     with:
       targets: >-
         [

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,6 +11,8 @@ on:
     types:
       - opened
       - synchronize
+    paths:
+      - .github/workflows/docker.yml
   pull_request_target:
     branches:
       - main
@@ -75,43 +77,21 @@ jobs:
   docker-ci:
     name: Docker CI
     needs: approval-gate
-    # pull_request_target はフォーク PR の head SHA をチェックアウトできない
-    # （GitHub のセキュリティ制約により actions/checkout が拒否するため）。
-    # フォーク PR かつ未マージの場合は、下の docker-ci-fork-preview（権限が
-    # 絞られた安全な pull_request トリガー側）にビルド検証を委ね、
-    # このジョブはスキップする。
-    if: >-
-      always() &&
-      needs.approval-gate.result == 'success' &&
-      github.event_name == 'pull_request_target' &&
-      (github.event.action != 'closed' || github.event.pull_request.merged == true) &&
-      !(github.event.pull_request.head.repo.full_name != github.repository && github.event.pull_request.merged != true)
-    uses: book000/templates/.github/workflows/reusable-docker.yml@249109e57d1bc836c5a4e1bbf4e446ad2c286deb # master
+    if: always() && needs.approval-gate.result == 'success' && (github.event.action != 'closed' || github.event.pull_request.merged == true)
+    # book000/templates#430（fix/allow-unsafe-pr-checkout-input, 未マージ）を暫定的に参照している。
+    # マージ後は master の SHA に更新すること。
+    uses: book000/templates/.github/workflows/reusable-docker.yml@0ae8b523900db5d32e3c2c2c2f1d286901c8e54a # fix/allow-unsafe-pr-checkout-input
     with:
       targets: >-
         [
           { imageName: "book000/mitm-packet-sniffer", context: "mitmproxy-addon", file: "mitmproxy-addon/Dockerfile", packageName: "mitm-packet-sniffer" }
         ]
       platforms: linux/amd64,linux/arm64
-    secrets:
-      DOCKER_USERNAME: ${{ github.actor }}
-      DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-
-  docker-ci-fork-preview:
-    name: Docker CI
-    # フォーク PR は pull_request_target 側でビルド検証できないため、
-    # 権限が絞られた安全な pull_request トリガーでビルド検証のみ行う
-    # （is-merged は常に false になるため、レジストリへの push は発生しない）
-    if: >-
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.head.repo.full_name != github.repository
-    uses: book000/templates/.github/workflows/reusable-docker.yml@249109e57d1bc836c5a4e1bbf4e446ad2c286deb # master
-    with:
-      targets: >-
-        [
-          { imageName: "book000/mitm-packet-sniffer", context: "mitmproxy-addon", file: "mitmproxy-addon/Dockerfile", packageName: "mitm-packet-sniffer" }
-        ]
-      platforms: linux/amd64,linux/arm64
+      # pull_request_target 上のフォーク PR は、actions/checkout のセキュリティ制約により
+      # デフォルトでは head SHA をチェックアウトできない。フォーク PR は上の approval-gate で
+      # Environment（fork-pr-build）の手動承認を既に必須にしているため、承認済みの場合に限り
+      # チェックアウトを許可する。
+      allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository }}
     secrets:
       DOCKER_USERNAME: ${{ github.actor }}
       DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 概要

`pull_request_target` トリガーでは `actions/checkout` がセキュリティ制約により、フォーク PR の head SHA をチェックアウトできません。

```
Refusing to check out fork pull request code from a 'pull_request_target' workflow.
This workflow runs with the base repository's GITHUB_TOKEN, secrets, ...
```

このため、フォーク PR では required status check `Docker CI / Check finished Docker CI` が常に失敗し、マージがブロックされます（PR #256 で発覚。本リポジトリで初のフォーク PR だったため、今まで顕在化していませんでした）。

## 変更内容

- `pull_request_target` 経由の `docker-ci` ジョブは、フォーク PR かつ未マージの場合はスキップするようにした
- 代わりに、権限が絞られた安全な `pull_request` トリガーで動作する `docker-ci-fork-preview` ジョブを追加し、フォーク PR のビルド検証を行うようにした（`is-merged` は常に `false` のためレジストリへの push は発生しない）
- `pull_request` トリガーの `paths` フィルタ（`docker.yml` 自身の変更時のみ動作する制限）を撤廃し、フォーク PR であれば常にビルド検証が走るようにした
  - 同一リポジトリの PR は従来どおり `pull_request_target` 側でのみ検証されるため、CI コストの増加はない（`docker-ci-fork-preview` はフォーク PR 以外では条件不成立でスキップされる）
- `book000/templates/reusable-docker.yml` は変更していない（プロジェクトルールにより変更対象外）

## 既知の制約

- フォーク PR に対する `approval-gate`（Environment `fork-pr-build` の手動承認）は、`pull_request_target` 側の `docker-ci` にのみ適用される。新設の `docker-ci-fork-preview` は権限が絞られた `pull_request` トリガーで動作するため、レジストリへの push・シークレットへのアクセスが発生せず、手動承認なしで自動実行される（GitHub Actions における fork PR 検証の標準的な安全策と同じ設計）
- 動作確認は本 PR 自体がフォーク PR（`akubiusa/mitm-packet-sniffer` → `book000/mitm-packet-sniffer`）であるため、この PR の CI 結果自体が実地検証になる